### PR TITLE
Changed UTouch to URTouch

### DIFF
--- a/ILI9341_due_Buttons.cpp
+++ b/ILI9341_due_Buttons.cpp
@@ -9,7 +9,7 @@
   Copyright (C)2015 Rinky-Dink Electronics, Henning Karlsen. All right reserved
 
   This library adds simple but easy to use buttons to extend the use
-  of the UTFT and UTouch libraries.
+  of the UTFT and URTouch libraries.
 
   You can find the latest version of the library at
   http://www.RinkyDinkElectronics.com/
@@ -26,14 +26,14 @@
   examples and tools supplied with the library.
 */
 
-#include "ILI9341_due_Buttons.h"    //.kbv defines UTouch_SPI
+#include "ILI9341_due_Buttons.h"    //.kbv defines URTouch_SPI
 #include <ILI9341_due.h>
 #include <URTouch.h>
 
-ILI9341_due_Buttons::ILI9341_due_Buttons(ILI9341_due *ptrILI9341, UTouch *ptrUTouch)
+ILI9341_due_Buttons::ILI9341_due_Buttons(ILI9341_due *ptrILI9341, URTouch *ptrURTouch)
 {
   _ILI9341 = ptrILI9341;
-  _UTouch = ptrUTouch;
+  _URTouch = ptrURTouch;
   deleteAllButtons();
   _color_text       = ILI9341_WHITE;
   _color_text_inactive  = ILI9341_GRAY;
@@ -207,12 +207,12 @@ void ILI9341_due_Buttons::deleteAllButtons()
 
 int ILI9341_due_Buttons::checkButtons()
 {
-  if (_UTouch->dataAvailable() == true)
+  if (_URTouch->dataAvailable() == true)
   {
-    _UTouch->read();
+    _URTouch->read();
     int   result = -1;
-    int   touch_x = _UTouch->getX();
-    int   touch_y = _UTouch->getY();
+    int   touch_x = _URTouch->getX();
+    int   touch_y = _URTouch->getY();
     //word  _current_color = _UTFT->getColor(); ???????????????????????
 
     for (int i = 0; i < MAX_BUTTONS; i++)
@@ -235,7 +235,7 @@ int ILI9341_due_Buttons::checkButtons()
       }
     }
 
-    while (_UTouch->dataAvailable() == true) {};
+    while (_URTouch->dataAvailable() == true) {};
 
     if (result != -1)
     {

--- a/ILI9341_due_Buttons.h
+++ b/ILI9341_due_Buttons.h
@@ -9,7 +9,7 @@
   Copyright (C)2015 Rinky-Dink Electronics, Henning Karlsen. All right reserved
   
   This library adds simple but easy to use buttons to extend the use
-  of the UTFT and UTouch libraries.
+  of the UTFT and URTouch libraries.
 
   You can find the latest version of the library at 
   http://www.RinkyDinkElectronics.com/
@@ -66,7 +66,7 @@ typedef struct
 class ILI9341_due_Buttons
 {
 	public:
-		ILI9341_due_Buttons(ILI9341_due *ptrILI9341, UTouch *ptrUTouch);
+		ILI9341_due_Buttons(ILI9341_due *ptrILI9341, URTouch *ptrURTouch);
 
 		int		addButton(uint16_t x, uint16_t y, uint16_t width, uint16_t height, char *label, uint16_t flags=0);
 		int		addButton(uint16_t x, uint16_t y, uint16_t width, uint16_t height, bitmapdatatype data, uint16_t flags=0);
@@ -85,7 +85,7 @@ class ILI9341_due_Buttons
 		
 	protected:
 		ILI9341_due *_ILI9341;
-		UTouch		*_UTouch;
+		URTouch		*_URTouch;
 		button_type	buttons[MAX_BUTTONS];
 		word		_color_text, _color_text_inactive, _color_background, _color_border, _color_hilite;
 		const uint8_t		*_font_text, *_font_symbol;


### PR DESCRIPTION
Sorry, I missed some.
Now all the UTouch are renamed to URTouch in the .cpp and .h files.
